### PR TITLE
Move the installation of 'awscli' to homebrew

### DIFF
--- a/omc
+++ b/omc
@@ -22,14 +22,9 @@ brew "siege"
 brew "maven"
 brew "gradle"
 brew "ant"
+brew "awscli"
 EOF
 echo
-
-# AWS credential stuff
-echo "Requesting sudo for 'easy_install pip'"
-sudo easy_install pip
-echo "Requesting sudo for 'pip install awscli'"
-sudo pip install awscli
 
 gem_install_or_update "aws-keychain-util"
 gem_install_or_update "aws-sdk-v1"


### PR DESCRIPTION
Rather than installing easy_install then pip to get
awscli, it is now offered via homebrew. Switch this
over so that we can leverage homebrew for system tasks
as much as possible.

This will allow simplified brew update / upgrade
usage without having to also remember to use pip