### PR TITLE
Remove Elixir related packages

### DIFF
--- a/omc
+++ b/omc
@@ -11,7 +11,6 @@ cask "java"
 cask "chefdk"
 
 brew "elasticsearch"
-brew "elixir"
 brew "memcached"
 brew "zookeeper"
 brew "gh"
@@ -29,9 +28,6 @@ echo
 gem_install_or_update "aws-keychain-util"
 gem_install_or_update "aws-sdk-v1"
 gem_install_or_update "hookup"
-
-# Elixir and Phoenix
-yes | mix local.hex
 
 # Install Pow
 if [ ! -f /Library/LaunchDaemons/cx.pow.firewall.plist ]; then


### PR DESCRIPTION
OMC at this point is not doing any elixir related work.
Removing these items to provide a clearer picture of
what OMC is using in development at this point in time.